### PR TITLE
Fix link to SLEIGH compiler usage in README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sleigh-compiler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleigh-compiler"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/sleigh-compiler"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ compiler.compile(input_file, output_file)?;
 
 The internal SLEIGH compiler is built from Ghidra 10.4.
 
-The SLEIGH compiler may report warnings in its response which reference command line switches. For details on any reported switches, refer to [SLEIGH compiler usage](ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc#L3687-L3701).
+The SLEIGH compiler may report warnings in its response which reference command line switches. For details on any reported switches, refer to [SLEIGH compiler usage](https://github.com/NationalSecurityAgency/ghidra/blob/1801dc1ee62be73faae29961ec2f17a59423f156/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc#L3736-L3747).
 
 ## Related Work
 


### PR DESCRIPTION
The link to the SLEIGH compiler usage in the README does not redirect correctly from crates.io. This updates the link to a direct link into the NSA repository.