### PR TITLE
Update internal sleigh compiler to Ghidra 11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0
+
+**Breaking change**: The SLEIGH compiler now produces _compressed_ .sla files. Tooling based on versions of Ghidra older than 11.1 will not understand this format. The uncompressed versions of .sla files can be produced by setting `debug_output` to `true` in the compiler options for compatibility with older tools.
+
+The Ghidra team does not plan to support use of uncompressed .sla files going forward ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)).
+
+### Changed
+
+- Updated the internal SLEIGH compiler to Ghidra 11.4
+
 ## 1.0.1
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sleigh-compiler"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleigh-compiler"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/sleigh-compiler"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/sleigh-compiler"
 description = "Rust bindings for the Ghidra SLEIGH compiler. Used to compile processor .slaspec files into .sla files"
+categories = ["security", "compilers", "api-bindings"]
 
 # List includes to avoid including entire Ghidra submodule
 include = [

--- a/README.md
+++ b/README.md
@@ -19,9 +19,26 @@ compiler.compile(input_file, output_file)?;
 
 ## Compiler Details
 
-The internal SLEIGH compiler is built from Ghidra 10.4.
+The internal SLEIGH compiler is built from Ghidra 11.4.
 
 The SLEIGH compiler may report warnings in its response which reference command line switches. For details on any reported switches, refer to [SLEIGH compiler usage](https://github.com/NationalSecurityAgency/ghidra/blob/1801dc1ee62be73faae29961ec2f17a59423f156/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc#L3736-L3747).
+
+### Compatibility
+
+In Ghidra 11.1 the .sla file format was changed to a compressed format. To produce .sla files compatible with tooling based on older versions of Ghidra, set `debug_output: true` in the compiler options.
+
+```rust
+let mut compiler = SleighCompiler::new(SleighCompilerOptions {
+    // This will produce .sla files compatible with older tooling
+    debug_output: true,
+    ..Default::default()
+});
+let input_file = std::path::Path::new("Ghidra/Processors/x86/data/languages/x86-64.slaspec");
+let output_file = std::path::Path::new("x86-64.sla");
+compiler.compile(input_file, output_file)?;
+```
+
+Note that these uncompressed files are _not_ compatible with tooling based on later versions of Ghidra, and the Ghidra team has no plans to add such support ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)).
 
 ## Related Work
 

--- a/build.rs
+++ b/build.rs
@@ -26,20 +26,37 @@ fn main() {
         "slghpattern.cc",
         "semantics.cc",
         "context.cc",
+        "slaformat.cc",   // New in Ghidra 11
+        "compression.cc", // New in Ghidra 11
         "filemanage.cc",
         // SLACOMP=slgh_compile slghparse slghscan
         "slghparse.cc",
         "slghscan.cc",
     ];
 
+    let zlib_path = Path::new("ghidra/Ghidra/Features/Decompiler/src/decompile/zlib");
+    const ZLIB_SOURCE_FILES: &[&str] = &[
+        "adler32.c",
+        "deflate.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "zutil.c",
+    ];
+
     cxx_build::bridge("src/ffi/sys.rs")
+        .define("LOCAL_ZLIB", "1")
+        .define("NO_GZIP", "1")
         .flag_if_supported("-std=c++14")
         .files(SLACOMP_SOURCE_FILES.iter().map(|s| source_path.join(s)))
+        .files(ZLIB_SOURCE_FILES.iter().map(|s| zlib_path.join(s)))
         .file("src/ffi/cpp/bridge.cc")
         // A fork of the slgh_compile.cc file is maintained locally to enable it
         // to be used as a library instead of as an executable
         .file("src/ffi/cpp/slgh_compile.cc")
         .include(source_path) // Header files coexist with cpp files
+        //.include(zlib_path) // Header files coexist with cpp files
         .warnings(false) // Not interested in the warnings for Ghidra code
         .compile("slacomp.a");
 

--- a/build.rs
+++ b/build.rs
@@ -56,7 +56,6 @@ fn main() {
         // to be used as a library instead of as an executable
         .file("src/ffi/cpp/slgh_compile.cc")
         .include(source_path) // Header files coexist with cpp files
-        //.include(zlib_path) // Header files coexist with cpp files
         .warnings(false) // Not interested in the warnings for Ghidra code
         .compile("slacomp.a");
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -49,6 +49,9 @@ pub struct SleighCompilerOptions {
 
     /// Set to `true` if register names are allowed to be case-sensitive
     pub case_sensitive_register_names: bool,
+
+    /// Set to `true` to write the output file using the debug (XML) form of the .sla format
+    pub debug_output: bool,
 }
 
 impl Default for SleighCompilerOptions {
@@ -64,6 +67,7 @@ impl Default for SleighCompilerOptions {
             enforce_local_keyword: false,
             large_temporary_warning: false,
             case_sensitive_register_names: false,
+            debug_output: false,
         }
     }
 }
@@ -89,6 +93,7 @@ impl SleighCompiler {
             options.enforce_local_keyword,
             options.large_temporary_warning,
             options.case_sensitive_register_names,
+            options.debug_output,
         );
 
         Self { compiler }

--- a/src/ffi/cpp/bridge.cc
+++ b/src/ffi/cpp/bridge.cc
@@ -8,7 +8,7 @@ void SleighCompileProxy::setAllOptionsProxy(
         const std::vector<PreprocessorDefine> &defines, bool unnecessaryPcodeWarning,
         bool lenientConflict, bool allCollisionWarning,
         bool allNopWarning,bool deadTempWarning,bool enforceLocalKeyWord,
-        bool largeTemporaryWarning, bool caseSensitiveRegisterNames) {
+        bool largeTemporaryWarning, bool caseSensitiveRegisterNames, bool debugOutput) {
 
     std::map<std::string, std::string> definesMap;
     for (auto &d : defines) {
@@ -18,7 +18,7 @@ void SleighCompileProxy::setAllOptionsProxy(
     setAllOptions(definesMap, unnecessaryPcodeWarning,
         lenientConflict, allCollisionWarning,
         allNopWarning, deadTempWarning, enforceLocalKeyWord,
-        largeTemporaryWarning, caseSensitiveRegisterNames);
+        largeTemporaryWarning, caseSensitiveRegisterNames, debugOutput);
 }
 
 CompileResponse SleighCompileProxy::run_compilation_proxy(const std::string &filein, const std::string &fileout) {

--- a/src/ffi/cpp/bridge.hh
+++ b/src/ffi/cpp/bridge.hh
@@ -19,7 +19,7 @@ class SleighCompileProxy : public ghidra::SleighCompile {
         void setAllOptionsProxy(const std::vector<PreprocessorDefine> &defines, bool unnecessaryPcodeWarning,
                 bool lenientConflict, bool allCollisionWarning,
                 bool allNopWarning, bool deadTempWarning, bool enforceLocalKeyWord,
-                bool largeTemporaryWarning, bool caseSensitiveRegisterNames);
+                bool largeTemporaryWarning, bool caseSensitiveRegisterNames, bool debugOutput);
         CompileResponse run_compilation_proxy(const std::string &filein, const std::string &fileout);
 };
 

--- a/src/ffi/sys.rs
+++ b/src/ffi/sys.rs
@@ -36,6 +36,7 @@ mod bridge {
             enforceLocalKeyWord: bool,
             largeTemporaryWarning: bool,
             caseSensitiveRegisterNames: bool,
+            debugOutput: bool,
         );
 
         #[rust_name = "run_compilation"]

--- a/tests/sleigh-compiler.rs
+++ b/tests/sleigh-compiler.rs
@@ -1,4 +1,4 @@
-use sleigh_compiler::SleighCompiler;
+use sleigh_compiler::{SleighCompiler, SleighCompilerOptions};
 
 #[test]
 fn compile_x86_x64() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,6 +16,28 @@ fn compile_x86_x64() -> Result<(), Box<dyn std::error::Error>> {
 
     compiler.compile(input_file, &output_file)?;
 
+    assert!(output_file.exists(), "compiled sla file should exist");
+    Ok(())
+}
+
+#[test]
+fn compile_x86_x64_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
+    let mut compiler = SleighCompiler::new(SleighCompilerOptions {
+        debug_output: true,
+        ..Default::default()
+    });
+    let mut input_file = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    input_file.push("ghidra/Ghidra/Processors/x86/data/languages/x86-64.slaspec");
+    assert!(input_file.exists(), "input slaspec file should exist");
+
+    let mut output_file = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    output_file.push("x86-64-uncompressed.sla");
+
+    if output_file.exists() {
+        std::fs::remove_file(&output_file)?;
+    }
+
+    compiler.compile(input_file, &output_file)?;
     assert!(output_file.exists(), "compiled sla file should exist");
     Ok(())
 }


### PR DESCRIPTION
This updates the internal compiler to use Ghidra 11.4. An important change here is the `.sla` file is now compressed, making this change a breaking change.