### PR TITLE
Improve compatibility notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0
 
-**Breaking change**: The SLEIGH compiler now produces _compressed_ .sla files. Tooling based on versions of Ghidra older than 11.1 will not understand this format. Tooling based on older versions of Ghidra should use version 1.0 of this compiler.
+💥 **Breaking change**: The SLEIGH compiler now produces _compressed_ .sla files. Tooling based on versions of Ghidra older than 11.1 will not understand this format. Tooling based on older versions of Ghidra should use version 1.0 of this compiler.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## 2.0.0
 
-**Breaking change**: The SLEIGH compiler now produces _compressed_ .sla files. Tooling based on versions of Ghidra older than 11.1 will not understand this format. The uncompressed versions of .sla files can be produced by setting `debug_output` to `true` in the compiler options for compatibility with older tools.
-
-The Ghidra team does not plan to support use of uncompressed .sla files going forward ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)).
+**Breaking change**: The SLEIGH compiler now produces _compressed_ .sla files. Tooling based on versions of Ghidra older than 11.1 will not understand this format. Tooling based on older versions of Ghidra should use version 1.0 of this compiler.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The SLEIGH compiler may report warnings in its response which reference command 
 
 ### Compatibility
 
-In Ghidra 11.1 the .sla file format was changed to a compressed format. If you wish to inspect the output in the uncompressed form set `debug_output` to `true`.
+In Ghidra 11.1 the .sla file format was changed to a compressed format. The uncompressed output can be obtained by setting `debug_output` to `true` in the compiler options.
 
 ```rust
 let mut compiler = SleighCompiler::new(SleighCompilerOptions {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The SLEIGH compiler may report warnings in its response which reference command 
 
 ### Compatibility
 
-In Ghidra 11.1 the .sla file format was changed to a compressed format. To produce .sla files compatible with tooling based on older versions of Ghidra, set `debug_output: true` in the compiler options.
+In Ghidra 11.1 the .sla file format was changed to a compressed format. If you wish to inspect the output in the uncompressed form set `debug_output` to `true`.
 
 ```rust
 let mut compiler = SleighCompiler::new(SleighCompilerOptions {
@@ -38,7 +38,7 @@ let output_file = std::path::Path::new("x86-64.sla");
 compiler.compile(input_file, output_file)?;
 ```
 
-Note that these uncompressed files are _not_ compatible with tooling based on later versions of Ghidra, and the Ghidra team has no plans to add such support ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)).
+💥 **These uncompressed files are _not_ compatible with _any_ tooling based on Ghidra**. Later versions of the tooling do not understand this format, and the Ghidra team has no plans to add such support ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)). Earlier versions of the tooling will reject the uncompressed file because the SLA format version has been bumped from `3` to `4`.
 
 ## Related Work
 


### PR DESCRIPTION
The original notes suggested that producing the uncompressed .sla file would be compatible with older tooling. Testing has confirmed that this not correct. The SLA format version has been bumped from 3 to 4, and so older tooling rejects the XML file on this basis. Overwriting this version to revert it back to 3 bypassed this but triggered further issues.

In short, the uncompressed format is not compatible with older tooling.