### PR TITLE
Include zlib code in crate publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ include = [
     "/build.rs",
     "/src/*",
     "/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/*",
+    "/ghidra/Ghidra/Features/Decompiler/src/decompile/zlib/*",
     "/ghidra/DISCLAIMER.md",
     "/ghidra/NOTICE",
     "/ghidra/LICENSE",


### PR DESCRIPTION
This is required to publish the crate with the new compiler.