### PR TITLE
Recommend v1 of compiler to interface with older tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sleigh-compiler"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleigh-compiler"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/sleigh-compiler"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ The SLEIGH compiler may report warnings in its response which reference command 
 
 ### Compatibility
 
-In Ghidra 11.1 the .sla file format was changed to a compressed format. The uncompressed output can be obtained by setting `debug_output` to `true` in the compiler options.
+In Ghidra 11.1 the .sla file format was changed to a compressed format. To interface with tooling based on versions of Ghidra older than 11.1, use version 1.0 of this crate.
+
+```sh
+cargo add sleigh-compiler@1
+```
+
+### Uncompressed Output
+
+The uncompressed form of the .sla file can be obtained by setting `debug_output` to `true` in the compiler options.
 
 ```rust
 let mut compiler = SleighCompiler::new(SleighCompilerOptions {
@@ -38,7 +46,7 @@ let output_file = std::path::Path::new("x86-64.sla");
 compiler.compile(input_file, output_file)?;
 ```
 
-💥 **These uncompressed files are _not_ compatible with _any_ tooling based on Ghidra**. Later versions of the tooling do not understand this format, and the Ghidra team has no plans to add such support ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)). Earlier versions of the tooling will reject the uncompressed file because the SLA format version has been bumped from `3` to `4`.
+Be aware that these uncompressed files are _not_ compatible with _any_ tooling based on Ghidra. Later versions of the tooling do not understand this format, and the Ghidra team has no plans to add such support ([#6416](https://github.com/NationalSecurityAgency/ghidra/issues/6416)). Earlier versions of the tooling will reject the uncompressed file because the SLA format version has been bumped from `3` to `4`.
 
 ## Related Work
 


### PR DESCRIPTION
Clarify README to indicate that version 1 of the compiler can be used to interface with older tooling.