### PR TITLE
Use libsla-sys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.0.2
+
+### Fixed
+
+- Duplicate object collisions when used with `libsla` no longer occur. Use `libsla-sys` crate instead of building Ghidra source.
+
+## 2.0.1
+
+### Changed
+
+- Clarified compatibility issues introduced in 2.0.0 in [README](README.md)
+
 ## 2.0.0
 
 💥 **Breaking change**: The SLEIGH compiler now produces _compressed_ .sla files. Tooling based on versions of Ghidra older than 11.1 will not understand this format. Tooling based on older versions of Ghidra should use version 1.0 of this compiler.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsla-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f692aac4a119667b9d3796b60a9f2853c6e54bc2201ff6494c80b34cd0bf0897"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,10 +221,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sleigh-compiler"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "cxx",
  "cxx-build",
+ "libsla-sys",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleigh-compiler"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/mnemonikr/sleigh-compiler"
@@ -22,6 +22,7 @@ include = [
 [dependencies]
 cxx = "1.0"
 thiserror = "2.0"
+libsla-sys = "0.1"
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ fn main() {
         .warnings(false) // Not interested in the warnings for Ghidra code
         .compile("slacomp");
 
-    println!("cargo:rustc-link-lib=libsla.a");
+    println!("cargo:rustc-link-lib=sla");
 
     // Rerun if any of the bindings have changed
     println!("cargo:rerun-if-changed=src/ffi/sys.rs");

--- a/build.rs
+++ b/build.rs
@@ -2,62 +2,19 @@ use std::path::Path;
 
 fn main() {
     let source_path = Path::new("ghidra/Ghidra/Features/Decompiler/src/decompile/cpp");
-
-    // The following sources were pulled from the Makefile
-    const SLACOMP_SOURCE_FILES: &[&str] = &[
-        // CORE=	xml marshal space float address pcoderaw translate opcodes globalcontext
-        "xml.cc",
-        "marshal.cc",
-        "space.cc",
-        "float.cc",
-        "address.cc",
-        "pcoderaw.cc",
-        "translate.cc",
-        "opcodes.cc",
-        "globalcontext.cc",
-        // SLEIGH=	sleigh pcodeparse pcodecompile sleighbase slghsymbol \
-        // slghpatexpress slghpattern semantics context filemanage
-        "sleigh.cc",
-        "pcodeparse.cc",
-        "pcodecompile.cc",
-        "sleighbase.cc",
-        "slghsymbol.cc",
-        "slghpatexpress.cc",
-        "slghpattern.cc",
-        "semantics.cc",
-        "context.cc",
-        "slaformat.cc",   // New in Ghidra 11
-        "compression.cc", // New in Ghidra 11
-        "filemanage.cc",
-        // SLACOMP=slgh_compile slghparse slghscan
-        "slghparse.cc",
-        "slghscan.cc",
-    ];
-
-    let zlib_path = Path::new("ghidra/Ghidra/Features/Decompiler/src/decompile/zlib");
-    const ZLIB_SOURCE_FILES: &[&str] = &[
-        "adler32.c",
-        "deflate.c",
-        "inffast.c",
-        "inflate.c",
-        "inftrees.c",
-        "trees.c",
-        "zutil.c",
-    ];
-
     cxx_build::bridge("src/ffi/sys.rs")
         .define("LOCAL_ZLIB", "1")
         .define("NO_GZIP", "1")
         .flag_if_supported("-std=c++14")
-        .files(SLACOMP_SOURCE_FILES.iter().map(|s| source_path.join(s)))
-        .files(ZLIB_SOURCE_FILES.iter().map(|s| zlib_path.join(s)))
         .file("src/ffi/cpp/bridge.cc")
         // A fork of the slgh_compile.cc file is maintained locally to enable it
         // to be used as a library instead of as an executable
         .file("src/ffi/cpp/slgh_compile.cc")
         .include(source_path) // Header files coexist with cpp files
         .warnings(false) // Not interested in the warnings for Ghidra code
-        .compile("slacomp.a");
+        .compile("slacomp");
+
+    println!("cargo:rustc-link-lib=libsla.a");
 
     // Rerun if any of the bindings have changed
     println!("cargo:rerun-if-changed=src/ffi/sys.rs");


### PR DESCRIPTION
This removes the internal build of the Ghidra Sleigh compiler and instead relies on the libsla-sys crate. This eliminates issues with object duplication by sharing a common crate.

The Ghidra source code is still needed for the header files to build the (modified) slgh_compile.cc.